### PR TITLE
feat: Add endpoint for sending reminder email with all upcoming appointments as described in User Story 15 

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,7 @@ app.use('/api/journals', journalRoutes);
 app.use('/api', moodRoutes);
 app.use('/api', communityRoutes);
 app.use('/api', therapyRoutes);
-app.use('/api', therapyChatRoutes)
+app.use('/api', therapyChatRoutes);
 app.use("/api", preferencesRoutes);
 app.use('/api', paymentRoutes)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2628,25 +2628,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "strnum": "^2.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -2667,6 +2648,25 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fecha": {
       "version": "4.2.3",

--- a/src/routes/therapyChatRoutes.js
+++ b/src/routes/therapyChatRoutes.js
@@ -12,3 +12,5 @@ router.get('/appointments/:id/chat', authMiddleware, sessionAuthMiddleware, acce
 // router.post('/therapy/chat/exit', authMiddleware, sessionAuthMiddleware, exitChatroom);
 router.delete('/therapy/chat/history', clearExpiredMessages);
 // router.post('/therapy/chat/notify', authMiddleware, sessionAuthMiddleware, sendNotification);
+
+module.exports = router;

--- a/src/routes/therapyRoutes.js
+++ b/src/routes/therapyRoutes.js
@@ -9,6 +9,7 @@ router.get('/therapists', therapyController.getAllTherapists);
 
 router.post('/appointments/', authMiddleware, therapyController.bookAppointment);
 router.get('/appointments/user', authMiddleware, therapyController.getUserAppointments);
+router.post('/appointments/email-reminder', authMiddleware, therapyController.sendUpcomingAppointmentReminders);
 router.get('/appointments/:appointmentID', therapyController.getSingleAppointment);
 router.get('/appointments', therapyController.getAllAppointments);
 

--- a/src/utils/formatAppointmentsForEmail.js
+++ b/src/utils/formatAppointmentsForEmail.js
@@ -1,0 +1,39 @@
+
+/**
+ * Utility function to format a list of appointments into a readable email body.
+ * @param {Array} appointments - List of appointments to summarize.
+ * @returns {{text: string, html: string}} - Formatted email content.
+ */
+
+const formatAppointmentsForEmail = (appointments) => {
+  let textSummary = "You have the following upcoming appointments:\n\n";
+  let htmlSummary = "<h2>Upcoming Appointment Reminders</h2><ul>";
+
+  appointments.forEach(app => {
+    // Formatting the date nicely for readability
+    const formattedDate = new Date(app.datetime).toLocaleString('en-US', {
+      weekday: 'long', 
+      year: 'numeric', 
+      month: 'long', 
+      day: 'numeric', 
+      hour: '2-digit', 
+      minute: '2-digit'
+    });
+    
+    const therapistName = app.therapist.name || 'Your Therapist'; 
+    const duration = app.duration;
+
+    textSummary += `- Therapist: ${therapistName}\n`;
+    textSummary += `  Time: ${formattedDate} (${duration} mins)\n\n`;
+
+    htmlSummary += `<li><strong>Therapist:</strong> ${therapistName}<br>`;
+    htmlSummary += `<strong>Time:</strong> ${formattedDate}<br>`;
+    htmlSummary += `<strong>Duration:</strong> ${duration} hours</li><br>`;
+  });
+  
+  htmlSummary += "</ul><p>Please log in to your dashboard to view more details.</p>";
+
+  return { text: textSummary, html: htmlSummary };
+}
+
+module.exports = {formatAppointmentsForEmail};


### PR DESCRIPTION
`POST /api/appointments/email-reminder` _Authentication required_

Example email:

```
Upcoming Appointment Reminders
Therapist: Dr. Jordan Peterson
Time: Tuesday, September 30, 2025 at 12:00 PM
Duration: 2 hours

Therapist: Dr. Jordan Peterson
Time: Tuesday, December 1, 2026 at 12:00 AM
Duration: 2 hours

Please log in to your dashboard to view more details.
```